### PR TITLE
Disables the autoloading of the login attempts log option

### DIFF
--- a/src/Core/SecureLogin.php
+++ b/src/Core/SecureLogin.php
@@ -177,7 +177,7 @@ class SecureLogin {
 			}
 		}
 
-		update_option( self::LOGIN_ATTEMPTS_LOG_OPTION, $log );
+		update_option( self::LOGIN_ATTEMPTS_LOG_OPTION, $log, false );
 	}
 
 	/**
@@ -369,6 +369,6 @@ class SecureLogin {
 			'timestamps' => $timestamps,
 		];
 
-		update_option( self::LOGIN_ATTEMPTS_LOG_OPTION, $log );
+		update_option( self::LOGIN_ATTEMPTS_LOG_OPTION, $log, false );
 	}
 }


### PR DESCRIPTION
## Description
This PR disables the autoloading of the login attempts log option.

That option could affect the site performance for sites with a significant number of failed login attempts.

## Connected Issue
See #37 

## Changelog
### Fixed
- Disabled the autoloading of the login attempts log option for performance reasons.