### PR TITLE
Fixes the Secure Login implementation to remove empty IP entries after the "Reset Entries" time is reached

### DIFF
--- a/src/Core/SecureLogin.php
+++ b/src/Core/SecureLogin.php
@@ -159,12 +159,7 @@ class SecureLogin {
 
 			// If no timestamps were found associated with the given IP, then reset the retries and lockouts.
 			if ( empty( $log['ips'][ $user_ip ]['timestamps'] ) ) {
-				$log['ips'][ $user_ip ]['retries']  = 0;
-				$log['ips'][ $user_ip ]['lockouts'] = 0;
-
-				if ( ! empty( $log['ips'][ $user_ip ]['lock_until'] ) ) {
-					unset( $log['ips'][ $user_ip ]['lock_until'] );
-				}
+				unset( $log['ips'][ $user_ip ] );
 
 				/**
 				 * Fires when an user IP is unblocked from your site.


### PR DESCRIPTION
## Description
This PR updates the Secure Login implementation to remove IP entries from the log, instead of resetting retries and lockouts, after the "Reset Entries" time is reached.

## Connected Issue
Closes https://github.com/supervisorwp/supervisor/issues/40

## Changelog
### Fixed
- Fixed the Secure Login implementation to remove empty IP entries after the "Reset Entries" time is reached.