### PR TITLE
Adds support for the new autoload values introduced in WordPress 6.6

### DIFF
--- a/src/Core/Autoload.php
+++ b/src/Core/Autoload.php
@@ -395,7 +395,12 @@ class Autoload {
 		$history = get_option( self::DEACTIVATION_HISTORY_OPTION );
 
 		if ( ! $history ) {
-			add_option( self::DEACTIVATION_HISTORY_OPTION, [], '', 'no' );
+			add_option(
+				self::DEACTIVATION_HISTORY_OPTION,
+				[],
+				'',
+				$this->determine_autoload_value( 'no' )
+			);
 
 			return [];
 		}


### PR DESCRIPTION
## Description
This PR adds support for the new autoload values introduced in WordPress 6.6.

https://make.wordpress.org/core/2024/06/18/options-api-disabling-autoload-for-large-options/

## Connected Issue
Closes #43 

## Changelog
### Changed
- Added support for the new autoload values introduced in WordPress 6.6.